### PR TITLE
Handle Camera Movement

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -18,7 +18,9 @@
             "compilerPath": "C:/raylib/w64devkit/bin/g++.exe",
             "cStandard": "c99",
             "cppStandard": "c++17",
-            "intelliSenseMode": "gcc-x64"
+            "intelliSenseMode": "gcc-x64",
+            "configurationProvider": "ms-vscode.cmake-tools",
+            "compileCommands": "${workspaceFolder}/build/compile_commands.json"
         }
     ],
     "version": 4

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
           "name": "Debug",
           "type": "cppdbg",
           "request": "launch",
-          "program": "${workspaceFolder}/build/raylib_tutorials.exe",
+          "program": "${workspaceFolder}/build/FishKing.exe",
           "args": [],
           "stopAtEntry": false,
           "cwd": "${workspaceFolder}",
@@ -42,10 +42,10 @@
           "cwd": "${workspaceFolder}",
           "environment": [],
           "externalConsole": false,
-          "program": "${workspaceFolder}/build/raylib_tutorials.exe",
+          "program": "${workspaceFolder}/build/FishKing.exe",
           "MIMode": "gdb",
           "windows": {
-            "program": "${workspaceFolder}/build/raylib_tutorials.exe",
+            "program": "${workspaceFolder}/build/FishKing.exe",
             "miDebuggerPath": "C:/raylib/w64devkit/bin/gdb.exe"
           },
           "osx": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -52,5 +52,5 @@
 		"streambuf": "cpp",
 		"typeinfo": "cpp"
 	},
-	"C_Cpp.default.compilerPath": "C:/raylib/w64devkit/bin/g++.exe"
+	"C_Cpp.default.compilerPath": "C:\\raylib\\w64devkit\\bin\\g++.exe"
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
-project(raylib_tutorials) # My Project Name
+project(FishKing) # My Project Name
+
+set_property(GLOBAL PROPERTY PROJECT_NAME "Fish King")
 
 # Set compiler flags for different build types
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")   # Debug flags

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,71 +1,124 @@
+#include <iostream>
 #include <cmath>
 #include <algorithm>
+#include <string>
 #include "raylib-cpp.hpp"
 #include "colors.hpp"
 
-void HandleCharacterMovement(raylib::Vector2& characterPos)
+using std::string;
+
+void HandleCharacterMovement(raylib::Vector2& characterPos, const float MovementSpeed)
 {
-    const float addition = 3.0f;
-    const float diagonalMultiply = sqrtf(4.5f) / addition;
+    
+    const float diagonalMultiply = sqrtf(powf(MovementSpeed, 2.0f) / 2) / MovementSpeed;
+    const raylib::Vector2 lastPos = raylib::Vector2(characterPos);
     raylib::Vector2 additionV = raylib::Vector2();
     additionV.x = (IsKeyDown(KEY_RIGHT)) ? 
-                    addition : (IsKeyDown(KEY_LEFT)) ? 
-                    -addition : 0;
+                    MovementSpeed : (IsKeyDown(KEY_LEFT)) ? 
+                    -MovementSpeed : 0;
     additionV.y = (IsKeyDown(KEY_DOWN)) ? 
-                    addition : (IsKeyDown(KEY_UP)) ? 
-                    -addition : 0;
+                    MovementSpeed : (IsKeyDown(KEY_UP)) ? 
+                    -MovementSpeed : 0;
     if(additionV.x != 0 && additionV.y != 0)
         additionV *= diagonalMultiply;
     characterPos += additionV;
 }
 
-void HandleEvents(raylib::Vector2& characterPos)
+void HandleEvents(raylib::Vector2& characterPos, const float MovementSpeed)
 {
-    HandleCharacterMovement(characterPos);
+    HandleCharacterMovement(characterPos, MovementSpeed);
     // maybe more event handling
 }
 
-void HandleDrawing(raylib::Window& window, const raylib::Vector2 characterPos, float& timeElapsed, int& backgroundIndex, bool& backgroundTransitionGoingForward)
+void HandleCamera(raylib::Camera2D& camera, const raylib::Vector2 CharacterPos)
 {
-    const float transitionDuration = 60.0f;
-
-    window.BeginDrawing();
-    {
-        window.ClearBackground(Colors::TransitionColorPalette(Colors::OCEAN_PALETTE, transitionDuration, timeElapsed, backgroundIndex, backgroundTransitionGoingForward));
-        DrawCircleV(characterPos, 5.0f, raylib::Color::Orange());
-
-        // more drawing
-    }
-    window.EndDrawing();
+    const float smoothFactor = 0.02f;
+    camera.target = Vector2Lerp(camera.target, CharacterPos, smoothFactor);
 }
 
+void HandleDrawing(raylib::Window& window, raylib::Camera2D& camera, const raylib::Vector2 characterPos)
+{
+    DrawCircleV(characterPos, 20.0f, raylib::Color::Orange());
+    
+    // raylib::Vector2 circle1 = camera.GetScreenToWorld({100, 100});
+    // raylib::Vector2 circle2 = camera.GetScreenToWorld({300, 100});
+    // raylib::Vector2 circle3 = camera.GetScreenToWorld({100, 300});
+    // raylib::Vector2 circle4 = camera.GetScreenToWorld({500, 300});
+    // raylib::Vector2 circle5 = camera.GetScreenToWorld({300, 500});
+    // DrawCircleV(circle1, 5.0f, raylib::Color::Black());
+    // DrawCircleV(circle2, 8.0f, raylib::Color::Black());
+    // DrawCircleV(circle3, 3.0f, raylib::Color::Black());
+    // DrawCircleV(circle4, 15.0f, raylib::Color::Black());
+    // DrawCircleV(circle5, 12.0f, raylib::Color::Black());
+    // more drawing
+}
+
+void WindowSettings(raylib::Window& window, const int TargetFPS, const raylib::Image& IconImage)
+{
+    window.SetTargetFPS(TargetFPS);
+    window.SetIcon(IconImage);
+}
+
+void HandleText(raylib::Window& window, raylib::Camera2D& camera, const int TargetFPS)
+{
+    const char* targetFPSStr = TargetFPS > 0 ? TextFormat("Target FPS: %i", TargetFPS) : "Target FPS: MAX";
+    raylib::Vector2 fpsPos = raylib::Vector2(50.0f, 50.0f);
+    DrawText(targetFPSStr, fpsPos.x, fpsPos.y, 20, BLACK);
+    DrawText(TextFormat("Current FPS: %i", window.GetFPS()), fpsPos.x, fpsPos.y + 50.0f, 20, BLACK);
+}
 
 int main() 
 {
     // Awake
-    const int screenWidth = 800;
-    const int screenHeight = 800;
-    const int targetFPS = 60;
+    const raylib::Vector2 ScreenSize = raylib::Vector2(800.0f, 800.0f);
+    const int TargetFPS = 120;
+    const float BackgroundTransitionDuration = 60.0f;
+    const float MovementSpeed = 3.0f;
+    const raylib::Image IconImage = raylib::Image("C:/Projects/Fish_King/assets/Fish/fish1.png");  
 
     float timeElapsed = 0.0f;
     int backgroundIndex = 0;
     bool backgroundTransitionGoingForward = true;
+    double previousTime = GetTime();
+    double currentTime = 0.0;
+    double updateDrawTime = 0.0;
+    float deltaTime = 0.0f;
+
     
-    raylib::Vector2 characterPos = raylib::Vector2(400.0f, 400.0f);
-    raylib::Color textColor = raylib::Color::Blue();
-    raylib::Window window(screenWidth, screenHeight, "Fish King");
+    raylib::Vector2 characterPos = raylib::Vector2();
+    raylib::Color textColor = raylib::Color::Black();
+    raylib::Camera2D camera = raylib::Camera2D({ScreenSize.x / 2, ScreenSize.y / 2}, {0.0f, 0.0f});
+    raylib::Window window(ScreenSize.x, ScreenSize.y, "Fish King");
 
     // Start
-    window.SetTargetFPS(targetFPS);
+    WindowSettings(window, TargetFPS, IconImage);
     
     // Update
     while(!window.ShouldClose())
     {
+        // std::cout << "Camera Target X: " << camera.target.x << " Y:" << camera.target.y << std::endl;
         // Event Handling
-        HandleEvents(characterPos);
+        HandleEvents(characterPos, MovementSpeed);
 
         // Drawing
-        HandleDrawing(window, characterPos, timeElapsed, backgroundIndex, backgroundTransitionGoingForward);
+        window.BeginDrawing();
+        {
+            window.ClearBackground(Colors::TransitionColorPalette(Colors::OCEAN_PALETTE, BackgroundTransitionDuration, timeElapsed, 
+                                                                    backgroundIndex, backgroundTransitionGoingForward));
+            camera.BeginMode();
+            {
+                // HandleCamera / UpdateCamera
+                HandleCamera(camera, characterPos);
+
+
+                HandleDrawing(window, camera, characterPos);
+            }
+            camera.EndMode();
+
+            // HandleText / HandleUI
+            HandleText(window, camera, TargetFPS);
+        }   
+        window.EndDrawing();
     }
 
     return 0;


### PR DESCRIPTION
End Goal:
* Player can't pass the screen margin "borders"
* When the player moves, the camera won't move (unless the player reaches the screen margin "borders")
* When the player isn't moving, the camera smoothly moves so it seems like the player is moving toward the center of the screen